### PR TITLE
feature(itchat): add UOS weixin desktop patch (#136)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 
 Added
 -----
+- Add UOS weixin desktop patch
 
 Changed
 -------

--- a/efb_wechat_slave/vendor/itchat/CHANGES
+++ b/efb_wechat_slave/vendor/itchat/CHANGES
@@ -13,6 +13,8 @@ Changes from other authors
   Fix 导入itchat的时候会打印黑色字符
 - ~~[luvletter2333/9c49b4a] == [littlecodersh#935]~~
   ~~UOS patch~~
+- [shejialuo/uos-patch-add] == [efb-wechat-slave#136]
+  add UOS weixin desktop patch
 
 
 Changes from Eana Hufwe

--- a/efb_wechat_slave/vendor/itchat/config.py
+++ b/efb_wechat_slave/vendor/itchat/config.py
@@ -7,3 +7,26 @@ OS = platform.system()  # Windows, Linux, Darwin
 DIR = os.getcwd()
 DEFAULT_QR = 'QR.png'
 TIMEOUT = (10, 60)
+
+UOS_PATCH_CLIENT_VERSION = '2.0.0'
+UOS_PATCH_EXTSPAM = (
+    'Go8FCIkFEokFCggwMDAwMDAwMRAGGvAESySibk50w5Wb3uT'
+    'l2c2h64jVVrV7gNs06GFlWplHQbY/5FfiO++1yH4ykCyNPW'
+    'KXmco+wfQzK5R98D3so7rJ5LmGFvBLjGceleySrc3SOf2Pc'
+    '1gVehzJgODeS0lDL3/I/0S2SSE98YgKleq6Uqx6ndTy9yaL'
+    '9qFxJL7eiA/R3SEfTaW1SBoSITIu+EEkXff+Pv8NHOk7N57'
+    'rcGk1w0ZzRrQDkXTOXFN2iHYIzAAZPIOY45Lsh+A4slpgnD'
+    'iaOvRtlQYCt97nmPLuTipOJ8Qc5pM7ZsOsAPPrCQL7nK0I7'
+    'aPrFDF0q4ziUUKettzW8MrAaiVfmbD1/VkmLNVqqZVvBCtR'
+    'blXb5FHmtS8FxnqCzYP4WFvz3T0TcrOqwLX1M/DQvcHaGGw'
+    '0B0y4bZMs7lVScGBFxMj3vbFi2SRKbKhaitxHfYHAOAa0X7'
+    '/MSS0RNAjdwoyGHeOepXOKY+h3iHeqCvgOH6LOifdHf/1aa'
+    'ZNwSkGotYnYScW8Yx63LnSwba7+hESrtPa/huRmB9KWvMCK'
+    'bDThL/nne14hnL277EDCSocPu3rOSYjuB9gKSOdVmWsj9Dx'
+    'b/iZIe+S6AiG29Esm+/eUacSba0k8wn5HhHg9d4tIcixrxv'
+    'eflc8vi2/wNQGVFNsGO6tB5WF0xf/plngOvQ1/ivGV/C1Qp'
+    'dhzznh0ExAVJ6dwzNg7qIEBaw+BzTJTUuRcPk92Sn6QDn2P'
+    'u3mpONaEumacjW4w6ipPnPw+g2TfywJjeEcpSZaP4Q3YV5H'
+    'G8D6UjWA4GSkBKculWpdCMadx0usMomsSS/74QgpYqcPkma'
+    'mB4nVv1JxczYITIqItIKjD35IGKAUwAA=='
+)


### PR DESCRIPTION
* feature(itchat): add UOS weixin desktop patch

It turns out that `wechat-uos` provided by Tencent still uses the web
interface, and someone finds the way to utilize the `wechat-uos` to
login into the web for the ones who cannot login by web. This commit
uses the information provided by the others. It does the three basic
things:

1. Change itchat `config.py` to add the corresponding version and
   `UOS_PATCH_EXTSPAM`.
2. Change itchat `components/login.py` to add the latest weixin check,
   `skey` field and `pass_ticket` field.
3. In order to get the message from weixin, eveytime the device ID
   should be changed, so this commit uses random string to generate
   the device ID.

However, this patch doesn't work for WeChat users.

* Add PR branch name

Co-authored-by: Eana Hufwe <eana@1a23.com>